### PR TITLE
[Feat/#26] 회원 정보 조회와 Role hierarchy 구현

### DIFF
--- a/src/main/java/com/nexters/momo/config/SecurityConfig.java
+++ b/src/main/java/com/nexters/momo/config/SecurityConfig.java
@@ -102,7 +102,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Bean
     public JwtLogoutSuccessHandler jwtLogoutSuccessHandler() {
-        return new JwtLogoutSuccessHandler(objectMapper);
+        return new JwtLogoutSuccessHandler();
     }
 
     @Bean

--- a/src/main/java/com/nexters/momo/config/SecurityConfig.java
+++ b/src/main/java/com/nexters/momo/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.nexters.momo.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nexters.momo.member.auth.application.MemberDetailsService;
 import com.nexters.momo.member.auth.application.RedisCachingService;
+import com.nexters.momo.member.auth.domain.Role;
 import com.nexters.momo.member.auth.filter.JwtAuthenticationFilter;
 import com.nexters.momo.member.auth.filter.LoginAuthenticationFilter;
 import com.nexters.momo.member.auth.handler.JwtLogoutHandler;
@@ -17,6 +18,7 @@ import com.nexters.momo.member.auth.provider.LoginAuthenticationProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.access.AccessDecisionManager;
 import org.springframework.security.access.AccessDecisionVoter;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
@@ -42,6 +44,14 @@ import java.util.List;
 @EnableWebSecurity
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
+    private static final String[] PUBLIC_GET_URI = {
+            "/actuator/**", "/swagger-ui/**"
+    };
+
+    private static final String[] PUBLIC_POST_URI = {
+            "/api/auth/register", "/api/auth/login"
+    };
+
     private final MemberDetailsService memberDetailsService;
     private final ObjectMapper objectMapper;
     private final JwtTokenFactory jwtTokenFactory;
@@ -63,7 +73,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             .and()
                 .authorizeRequests()
-                .anyRequest().permitAll()
+                .antMatchers(HttpMethod.GET, PUBLIC_GET_URI).permitAll()
+                .antMatchers(HttpMethod.POST, PUBLIC_POST_URI).permitAll()
+                .antMatchers("/api/**").hasRole(Role.USER.name())
+                .anyRequest().authenticated()
                 .accessDecisionManager(affirmativeBased());
 
         http

--- a/src/main/java/com/nexters/momo/member/auth/application/MemberService.java
+++ b/src/main/java/com/nexters/momo/member/auth/application/MemberService.java
@@ -4,24 +4,40 @@ import com.nexters.momo.member.auth.domain.Member;
 import com.nexters.momo.member.auth.domain.MemberRepository;
 import com.nexters.momo.member.auth.exception.DuplicatedUserDeviceIdException;
 import com.nexters.momo.member.auth.exception.DuplicatedUserEmailException;
+import com.nexters.momo.member.auth.exception.UserNotFoundException;
 import com.nexters.momo.member.auth.presentation.dto.MemberRegisterRequest;
+import com.nexters.momo.member.mypage.common.dto.response.AttendanceDto;
+import com.nexters.momo.member.mypage.common.dto.response.MemberInfoDto;
+import com.nexters.momo.member.mypage.common.dto.response.MemberLookUpResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class MemberService {
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
 
-    @Transactional
     public void register(MemberRegisterRequest memberRegisterRequest) {
         checkAlreadyExistsUser(memberRegisterRequest.getEmail(), memberRegisterRequest.getUuid());
         Member newMember = createMember(memberRegisterRequest);
         memberRepository.save(newMember);
+    }
+
+    @Transactional(readOnly = true)
+    public MemberLookUpResponse findUserWithDetailInfo(Long memberId) {
+        MemberInfoDto findMemberInfoDto = memberRepository.findMemberInfoById(memberId)
+                .orElseThrow(UserNotFoundException::new);
+
+        List<AttendanceDto> attendanceDtoList = memberRepository.findMemberAttendanceInfoById(memberId);
+
+        return MemberLookUpResponse.of(findMemberInfoDto, attendanceDtoList);
     }
 
     private Member createMember(MemberRegisterRequest request) {

--- a/src/main/java/com/nexters/momo/member/auth/application/MemberService.java
+++ b/src/main/java/com/nexters/momo/member/auth/application/MemberService.java
@@ -4,10 +4,8 @@ import com.nexters.momo.member.auth.domain.Member;
 import com.nexters.momo.member.auth.domain.MemberRepository;
 import com.nexters.momo.member.auth.exception.DuplicatedUserDeviceIdException;
 import com.nexters.momo.member.auth.exception.DuplicatedUserEmailException;
-import com.nexters.momo.member.auth.exception.UserNotFoundException;
 import com.nexters.momo.member.auth.presentation.dto.MemberRegisterRequest;
 import com.nexters.momo.member.mypage.common.dto.response.AttendanceDto;
-import com.nexters.momo.member.mypage.common.dto.response.MemberInfoDto;
 import com.nexters.momo.member.mypage.common.dto.response.MemberLookUpResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -31,13 +29,10 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
-    public MemberLookUpResponse findUserWithDetailInfo(Long memberId) {
-        MemberInfoDto findMemberInfoDto = memberRepository.findMemberInfoById(memberId)
-                .orElseThrow(UserNotFoundException::new);
+    public MemberLookUpResponse findUserWithDetailInfo(Member member) {
+        List<AttendanceDto> attendanceDtoList = memberRepository.findMemberAttendanceInfoById(member.getId());
 
-        List<AttendanceDto> attendanceDtoList = memberRepository.findMemberAttendanceInfoById(memberId);
-
-        return MemberLookUpResponse.of(findMemberInfoDto, attendanceDtoList);
+        return MemberLookUpResponse.of(member, attendanceDtoList);
     }
 
     private Member createMember(MemberRegisterRequest request) {

--- a/src/main/java/com/nexters/momo/member/auth/application/RoleHierarchyService.java
+++ b/src/main/java/com/nexters/momo/member/auth/application/RoleHierarchyService.java
@@ -1,0 +1,36 @@
+package com.nexters.momo.member.auth.application;
+
+import com.nexters.momo.member.auth.domain.RoleHierarchy;
+import com.nexters.momo.member.auth.domain.RoleHierarchyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Iterator;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RoleHierarchyService {
+
+    private final RoleHierarchyRepository roleHierarchyRepository;
+
+    @Transactional(readOnly = true)
+    public String AllHierarchyToString() {
+        List<RoleHierarchy> rolesHierarchy = roleHierarchyRepository.findAll();
+
+        Iterator<RoleHierarchy> iterator = rolesHierarchy.iterator();
+        StringBuffer concatedRoles = new StringBuffer();
+        while (iterator.hasNext()) {
+            RoleHierarchy model = iterator.next();
+            if (model.getParentName() != null) {
+                concatedRoles.append(model.getParentName().getChildName());
+                concatedRoles.append(" > ");
+                concatedRoles.append(model.getChildName());
+                concatedRoles.append("\n");
+            }
+        }
+
+        return concatedRoles.toString();
+    }
+}

--- a/src/main/java/com/nexters/momo/member/auth/domain/Member.java
+++ b/src/main/java/com/nexters/momo/member/auth/domain/Member.java
@@ -85,10 +85,6 @@ public class Member {
         return deleted;
     }
 
-    public Long getId() {
-        return id;
-    }
-
     public void changeActive(boolean active) {
         this.active = active;
     }
@@ -101,8 +97,16 @@ public class Member {
         memberRoles.add(new Authority(role));
     }
 
+    public boolean isSameDeviceId(String uuid) {
+        return this.deviceUniqueId.equals(uuid);
+    }
+
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return new ArrayList<>(memberRoles);
+    }
+
+    public Long getId() {
+        return id;
     }
 
     public String getPassword() {
@@ -113,8 +117,12 @@ public class Member {
         return this.email.getValue();
     }
 
-    public boolean isSameDeviceId(String uuid) {
-        return this.deviceUniqueId.equals(uuid);
+    public String getName() {
+        return name.getValue();
+    }
+
+    public Occupation getOccupation() {
+        return occupation;
     }
 
     @Override

--- a/src/main/java/com/nexters/momo/member/auth/domain/MemberQueryRepository.java
+++ b/src/main/java/com/nexters/momo/member/auth/domain/MemberQueryRepository.java
@@ -1,0 +1,14 @@
+package com.nexters.momo.member.auth.domain;
+
+import com.nexters.momo.member.mypage.common.dto.response.AttendanceDto;
+import com.nexters.momo.member.mypage.common.dto.response.MemberInfoDto;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MemberQueryRepository {
+
+    Optional<MemberInfoDto> findMemberInfoById(Long memberId);
+
+    List<AttendanceDto> findMemberAttendanceInfoById(Long memberId);
+}

--- a/src/main/java/com/nexters/momo/member/auth/domain/MemberQueryRepositoryImpl.java
+++ b/src/main/java/com/nexters/momo/member/auth/domain/MemberQueryRepositoryImpl.java
@@ -1,0 +1,40 @@
+package com.nexters.momo.member.auth.domain;
+
+import com.nexters.momo.member.mypage.common.dto.response.AttendanceDto;
+import com.nexters.momo.member.mypage.common.dto.response.MemberInfoDto;
+import com.nexters.momo.member.mypage.common.dto.response.QAttendanceDto;
+import com.nexters.momo.member.mypage.common.dto.response.QMemberInfoDto;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.nexters.momo.attendance.domain.QAttendance.attendance;
+import static com.nexters.momo.member.auth.domain.QMember.member;
+
+@RequiredArgsConstructor
+public class MemberQueryRepositoryImpl implements MemberQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<MemberInfoDto> findMemberInfoById(Long memberId) {
+        MemberInfoDto memberInfoDto = queryFactory
+                .select(new QMemberInfoDto(member.active, member.name.value, member.email.value, member.occupation))
+                .from(member)
+                .where(member.id.eq(memberId))
+                .fetchOne();
+
+        return Optional.of(memberInfoDto);
+    }
+
+    @Override
+    public List<AttendanceDto> findMemberAttendanceInfoById(Long memberId) {
+        return queryFactory
+                .select(new QAttendanceDto(attendance.status, attendance.createTime))
+                .from(attendance)
+                .where(attendance.memberId.eq(memberId))
+                .fetch();
+    }
+}

--- a/src/main/java/com/nexters/momo/member/auth/domain/MemberRepository.java
+++ b/src/main/java/com/nexters/momo/member/auth/domain/MemberRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberQueryRepository {
 
     @Query("select m from Member m where m.email.value = :email")
     Optional<Member> findByEmail(@Param("email") String email);

--- a/src/main/java/com/nexters/momo/member/auth/domain/Name.java
+++ b/src/main/java/com/nexters/momo/member/auth/domain/Name.java
@@ -28,5 +28,9 @@ public class Name {
     private boolean isValidName(String name) {
         return name.length() > MIN_LENGTH && name.length() < MAX_LENGTH;
     }
+
+    public String getValue() {
+        return value;
+    }
 }
 

--- a/src/main/java/com/nexters/momo/member/auth/domain/RoleHierarchy.java
+++ b/src/main/java/com/nexters/momo/member/auth/domain/RoleHierarchy.java
@@ -1,0 +1,60 @@
+package com.nexters.momo.member.auth.domain;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString(exclude = {"parentName", "roleHierarchy"})
+public class RoleHierarchy {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "role_hierarchy_id")
+    private Long id;
+
+    private String childName;
+
+    @ManyToOne(cascade = {CascadeType.ALL}, fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_name", referencedColumnName = "child_name")
+    private RoleHierarchy parentName;
+
+    @OneToMany(mappedBy = "parentName", cascade = {CascadeType.ALL})
+    private Set<RoleHierarchy> roleHierarchy = new HashSet<RoleHierarchy>();
+
+    private RoleHierarchy(String childName) {
+        this.childName = childName;
+    }
+
+    public static RoleHierarchy createWithChildName(String role) {
+        return new RoleHierarchy(role);
+    }
+
+    public String getChildName() {
+        return childName;
+    }
+
+    public RoleHierarchy getParentName() {
+        return parentName;
+    }
+
+    public void setParentName(RoleHierarchy parentName) {
+        this.parentName = parentName;
+    }
+}
+
+

--- a/src/main/java/com/nexters/momo/member/auth/domain/RoleHierarchy.java
+++ b/src/main/java/com/nexters/momo/member/auth/domain/RoleHierarchy.java
@@ -14,19 +14,21 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
+import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @ToString(exclude = {"parentName", "roleHierarchy"})
-public class RoleHierarchy {
+public class RoleHierarchy implements Serializable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "role_hierarchy_id")
     private Long id;
 
+    @Column(name = "child_name")
     private String childName;
 
     @ManyToOne(cascade = {CascadeType.ALL}, fetch = FetchType.LAZY)

--- a/src/main/java/com/nexters/momo/member/auth/domain/RoleHierarchyRepository.java
+++ b/src/main/java/com/nexters/momo/member/auth/domain/RoleHierarchyRepository.java
@@ -1,0 +1,10 @@
+package com.nexters.momo.member.auth.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RoleHierarchyRepository extends JpaRepository<RoleHierarchy, Long> {
+
+    Optional<RoleHierarchy> findByChildName(String roleName);
+}

--- a/src/main/java/com/nexters/momo/member/auth/handler/JwtLogoutSuccessHandler.java
+++ b/src/main/java/com/nexters/momo/member/auth/handler/JwtLogoutSuccessHandler.java
@@ -1,29 +1,19 @@
 package com.nexters.momo.member.auth.handler;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 public class JwtLogoutSuccessHandler implements LogoutSuccessHandler {
 
-    private final ObjectMapper objectMapper;
-
-    public JwtLogoutSuccessHandler(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
-
     @Override
-    public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+    public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
         setLogoutHeader(response);
-        objectMapper.writeValue(response.getWriter(), response);
     }
 
     private static void setLogoutHeader(HttpServletResponse response) {

--- a/src/main/java/com/nexters/momo/member/auth/listener/SetupDataLoader.java
+++ b/src/main/java/com/nexters/momo/member/auth/listener/SetupDataLoader.java
@@ -1,0 +1,49 @@
+package com.nexters.momo.member.auth.listener;
+
+import com.nexters.momo.member.auth.domain.Role;
+import com.nexters.momo.member.auth.domain.RoleHierarchy;
+import com.nexters.momo.member.auth.domain.RoleHierarchyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class SetupDataLoader implements ApplicationListener<ContextRefreshedEvent> {
+
+    private final RoleHierarchyRepository roleHierarchyRepository;
+
+    private boolean alreadySetup = false;
+
+    @Transactional
+    @Override
+    public void onApplicationEvent(final ContextRefreshedEvent event) {
+        if (alreadySetup) {
+            return;
+        }
+
+        setupSecurityResources();
+        alreadySetup = true;
+    }
+
+    private void setupSecurityResources() {
+        createRoleHierarchyIfNotFound(Role.USER, Role.ADMIN);
+        createRoleHierarchyIfNotFound(Role.ANONYMOUS, Role.USER);
+    }
+
+    private void createRoleHierarchyIfNotFound(Role childRole, Role parentRole) {
+        RoleHierarchy parentRoleHierarchy = getRoleHierarchy(parentRole);
+        RoleHierarchy childRoleHierarchy = getRoleHierarchy(childRole);
+        childRoleHierarchy.setParentName(parentRoleHierarchy);
+    }
+
+    private RoleHierarchy getRoleHierarchy(Role role) {
+        RoleHierarchy roleHierarchy = roleHierarchyRepository.findByChildName(role.getRole())
+                .orElseGet(() -> RoleHierarchy.createWithChildName(role.getRole()));
+
+        return roleHierarchyRepository.save(roleHierarchy);
+    }
+}
+

--- a/src/main/java/com/nexters/momo/member/auth/utils/SecurityInitializer.java
+++ b/src/main/java/com/nexters/momo/member/auth/utils/SecurityInitializer.java
@@ -1,0 +1,23 @@
+package com.nexters.momo.member.auth.utils;
+
+import com.nexters.momo.member.auth.application.RoleHierarchyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SecurityInitializer implements ApplicationRunner {
+
+    private final RoleHierarchyService roleHierarchyService;
+
+    private final RoleHierarchyImpl roleHierarchy;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        String allHierarchy = roleHierarchyService.AllHierarchyToString();
+        roleHierarchy.setHierarchy(allHierarchy);
+    }
+}

--- a/src/main/java/com/nexters/momo/member/mypage/common/dto/response/AttendanceDto.java
+++ b/src/main/java/com/nexters/momo/member/mypage/common/dto/response/AttendanceDto.java
@@ -1,0 +1,23 @@
+package com.nexters.momo.member.mypage.common.dto.response;
+
+import com.nexters.momo.attendance.domain.AttendanceStatus;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class AttendanceDto {
+
+    private AttendanceStatus attendanceStatus;
+
+    private LocalDateTime attendanceTime;
+
+    @QueryProjection
+    public AttendanceDto(AttendanceStatus attendanceStatus, LocalDateTime attendanceTime) {
+        this.attendanceStatus = attendanceStatus;
+        this.attendanceTime = attendanceTime;
+    }
+}

--- a/src/main/java/com/nexters/momo/member/mypage/common/dto/response/MemberInfoDto.java
+++ b/src/main/java/com/nexters/momo/member/mypage/common/dto/response/MemberInfoDto.java
@@ -1,0 +1,27 @@
+package com.nexters.momo.member.mypage.common.dto.response;
+
+import com.nexters.momo.member.auth.domain.Occupation;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemberInfoDto {
+
+    private boolean active;
+
+    private String name;
+
+    private String email;
+
+    private Occupation occupation;
+
+    @QueryProjection
+    public MemberInfoDto(boolean active, String name, String email, Occupation occupation) {
+        this.active = active;
+        this.name = name;
+        this.email = email;
+        this.occupation = occupation;
+    }
+}

--- a/src/main/java/com/nexters/momo/member/mypage/common/dto/response/MemberLookUpResponse.java
+++ b/src/main/java/com/nexters/momo/member/mypage/common/dto/response/MemberLookUpResponse.java
@@ -1,6 +1,7 @@
 package com.nexters.momo.member.mypage.common.dto.response;
 
 import com.nexters.momo.attendance.domain.AttendanceStatus;
+import com.nexters.momo.member.auth.domain.Member;
 import com.nexters.momo.member.auth.domain.Occupation;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -38,7 +39,7 @@ public class MemberLookUpResponse {
         this.attendanceHistories = attendanceHistories;
     }
 
-    public static MemberLookUpResponse of(MemberInfoDto info, List<AttendanceDto> attendanceList) {
+    public static MemberLookUpResponse of(Member member, List<AttendanceDto> attendanceList) {
         long absentCnt = 0;
         long attendanceCnt = 0;
         long lateCnt = 0;
@@ -53,6 +54,6 @@ public class MemberLookUpResponse {
             }
         }
 
-        return new MemberLookUpResponse(info.isActive(), info.getName(), info.getEmail(), info.getOccupation(), absentCnt, attendanceCnt, lateCnt, attendanceList);
+        return new MemberLookUpResponse(member.isActive(), member.getName(), member.getEmail(), member.getOccupation(), absentCnt, attendanceCnt, lateCnt, attendanceList);
     }
 }

--- a/src/main/java/com/nexters/momo/member/mypage/common/dto/response/MemberLookUpResponse.java
+++ b/src/main/java/com/nexters/momo/member/mypage/common/dto/response/MemberLookUpResponse.java
@@ -1,0 +1,58 @@
+package com.nexters.momo.member.mypage.common.dto.response;
+
+import com.nexters.momo.attendance.domain.AttendanceStatus;
+import com.nexters.momo.member.auth.domain.Occupation;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class MemberLookUpResponse {
+
+    private boolean active;
+
+    private String name;
+
+    private String email;
+
+    private Occupation occupation;
+
+    private Long absentCount;
+
+    private Long attendanceCount;
+
+    private Long lateCount;
+
+    private List<AttendanceDto> attendanceHistories;
+
+    private MemberLookUpResponse(boolean active, String name, String email, Occupation occupation, Long absentCount, Long attendanceCount, Long lateCount, List<AttendanceDto> attendanceHistories) {
+        this.active = active;
+        this.name = name;
+        this.email = email;
+        this.occupation = occupation;
+        this.absentCount = absentCount;
+        this.attendanceCount = attendanceCount;
+        this.lateCount = lateCount;
+        this.attendanceHistories = attendanceHistories;
+    }
+
+    public static MemberLookUpResponse of(MemberInfoDto info, List<AttendanceDto> attendanceList) {
+        long absentCnt = 0;
+        long attendanceCnt = 0;
+        long lateCnt = 0;
+
+        for (AttendanceDto attendanceDto : attendanceList) {
+            if (attendanceDto.getAttendanceStatus().equals(AttendanceStatus.ABSENT)) {
+                absentCnt += 1;
+            } else if (attendanceDto.getAttendanceStatus().equals(AttendanceStatus.ATTENDANCE)) {
+                attendanceCnt += 1;
+            } else if (attendanceDto.getAttendanceStatus().equals(AttendanceStatus.LATE)) {
+                lateCnt += 1;
+            }
+        }
+
+        return new MemberLookUpResponse(info.isActive(), info.getName(), info.getEmail(), info.getOccupation(), absentCnt, attendanceCnt, lateCnt, attendanceList);
+    }
+}

--- a/src/main/java/com/nexters/momo/member/mypage/presentation/MyPageController.java
+++ b/src/main/java/com/nexters/momo/member/mypage/presentation/MyPageController.java
@@ -1,18 +1,14 @@
 package com.nexters.momo.member.mypage.presentation;
 
-import com.nexters.momo.common.response.BaseResponse;
 import com.nexters.momo.member.auth.application.MemberService;
 import com.nexters.momo.member.auth.domain.Member;
 import com.nexters.momo.member.mypage.common.dto.response.MemberLookUpResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import static com.nexters.momo.common.response.ResponseCodeAndMessages.MEMBER_INFORMATION_LOOKUP_SUCCESS;
 
 @RequiredArgsConstructor
 @RestController
@@ -22,8 +18,8 @@ public class MyPageController {
     private final MemberService memberService;
 
     @GetMapping("/me")
-    public ResponseEntity<BaseResponse<MemberLookUpResponse>> searchMe(@AuthenticationPrincipal Member member) {
+    public ResponseEntity<MemberLookUpResponse> searchMe(@AuthenticationPrincipal Member member) {
         MemberLookUpResponse memberLookUpResponse = memberService.findUserWithDetailInfo(member.getId());
-        return new ResponseEntity(new BaseResponse(MEMBER_INFORMATION_LOOKUP_SUCCESS, memberLookUpResponse), HttpStatus.OK);
+        return ResponseEntity.ok().body(memberLookUpResponse);
     }
 }

--- a/src/main/java/com/nexters/momo/member/mypage/presentation/MyPageController.java
+++ b/src/main/java/com/nexters/momo/member/mypage/presentation/MyPageController.java
@@ -19,7 +19,7 @@ public class MyPageController {
 
     @GetMapping("/me")
     public ResponseEntity<MemberLookUpResponse> searchMe(@AuthenticationPrincipal Member member) {
-        MemberLookUpResponse memberLookUpResponse = memberService.findUserWithDetailInfo(member.getId());
+        MemberLookUpResponse memberLookUpResponse = memberService.findUserWithDetailInfo(member);
         return ResponseEntity.ok().body(memberLookUpResponse);
     }
 }

--- a/src/main/java/com/nexters/momo/member/mypage/presentation/MyPageController.java
+++ b/src/main/java/com/nexters/momo/member/mypage/presentation/MyPageController.java
@@ -1,0 +1,29 @@
+package com.nexters.momo.member.mypage.presentation;
+
+import com.nexters.momo.common.response.BaseResponse;
+import com.nexters.momo.member.auth.application.MemberService;
+import com.nexters.momo.member.auth.domain.Member;
+import com.nexters.momo.member.mypage.common.dto.response.MemberLookUpResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.nexters.momo.common.response.ResponseCodeAndMessages.MEMBER_INFORMATION_LOOKUP_SUCCESS;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/mypages")
+public class MyPageController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/me")
+    public ResponseEntity<BaseResponse<MemberLookUpResponse>> searchMe(@AuthenticationPrincipal Member member) {
+        MemberLookUpResponse memberLookUpResponse = memberService.findUserWithDetailInfo(member.getId());
+        return new ResponseEntity(new BaseResponse(MEMBER_INFORMATION_LOOKUP_SUCCESS, memberLookUpResponse), HttpStatus.OK);
+    }
+}

--- a/src/test/java/com/nexters/momo/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/com/nexters/momo/acceptance/AuthAcceptanceTest.java
@@ -47,7 +47,7 @@ public class AuthAcceptanceTest extends RandomPortConfigure {
         var 사용자_가입_응답 = 사용자_가입_요청(memberRegisterRequest);
 
         // then
-        사용자_가입_응답_확인(사용자_가입_응답, HttpStatus.CREATED, "유저 생성에 성공했습니다");
+        사용자_가입_응답_확인(사용자_가입_응답, HttpStatus.CREATED);
     }
 
     /**
@@ -67,7 +67,7 @@ public class AuthAcceptanceTest extends RandomPortConfigure {
         var 사용자_가입_응답 = 사용자_가입_요청(memberRegisterRequest);
 
         // then
-        사용자_가입_응답_확인(사용자_가입_응답, HttpStatus.BAD_REQUEST, "유저 생성에 실패했습니다");
+        사용자_가입_응답_확인(사용자_가입_응답, HttpStatus.BAD_REQUEST);
     }
 
     /**

--- a/src/test/java/com/nexters/momo/acceptance/AuthStep.java
+++ b/src/test/java/com/nexters/momo/acceptance/AuthStep.java
@@ -15,12 +15,8 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 public class AuthStep {
 
-    public static void 사용자_가입_응답_확인(ExtractableResponse<Response> response, HttpStatus status, String message) {
-        assertAll(
-                () -> assertThat(response.statusCode()).isEqualTo(status.value()),
-                () -> assertThat(response.jsonPath().getInt("code")).isEqualTo(status.value()),
-                () -> assertThat(response.jsonPath().getString("message")).isEqualTo(message)
-        );
+    public static void 사용자_가입_응답_확인(ExtractableResponse<Response> response, HttpStatus status) {
+        assertThat(response.statusCode()).isEqualTo(status.value());
     }
 
     public static ExtractableResponse<Response> 사용자_가입_요청(MemberRegisterRequest memberRegisterRequest) {
@@ -36,9 +32,8 @@ public class AuthStep {
     public static void 로그인_응답_확인(ExtractableResponse<Response> response, HttpStatus status) {
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(status.value()),
-                () -> assertThat(response.jsonPath().getInt("code")).isEqualTo(HttpStatus.OK.value()),
-                () -> assertThat(response.jsonPath().getString("data.accessToken")).isNotBlank(),
-                () -> assertThat(response.jsonPath().getString("data.refreshToken")).isNotBlank()
+                () -> assertThat(response.jsonPath().getString("body.accessToken")).isNotBlank(),
+                () -> assertThat(response.jsonPath().getString("body.refreshToken")).isNotBlank()
         );
     }
 
@@ -58,7 +53,7 @@ public class AuthStep {
 
     public static String 로그인_되어_있음(String email, String password, String uuid) {
         ExtractableResponse<Response> response = 로그인_요청(email, password, uuid);
-        return response.jsonPath().getString("data.accessToken");
+        return response.jsonPath().getString("body.accessToken");
     }
 
     public static ExtractableResponse<Response> 로그아웃_요청(String accessToken) {
@@ -72,15 +67,13 @@ public class AuthStep {
     }
 
     public static void 로그아웃_응답_확인(ExtractableResponse<Response> response) {
-        assertThat(response.jsonPath().getInt("code")).isEqualTo(200);
+        assertThat(response.statusCode()).isEqualTo(200);
     }
 
     public static void 로그인_응답_실패_확인(ExtractableResponse<Response> response, HttpStatus status, String message) {
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(status.value()),
-                () -> assertThat(response.jsonPath().getInt("code")).isEqualTo(status.value()),
-                () -> assertThat(response.jsonPath().getString("message")).isEqualTo(message),
-                () -> assertThat(response.jsonPath().getString("data")).isNull()
+                () -> assertThat(response.jsonPath().getString("message")).isEqualTo(message)
         );
     }
 }

--- a/src/test/java/com/nexters/momo/acceptance/MyPageAcceptanceTest.java
+++ b/src/test/java/com/nexters/momo/acceptance/MyPageAcceptanceTest.java
@@ -1,6 +1,7 @@
 package com.nexters.momo.acceptance;
 
 import com.nexters.momo.member.auth.presentation.dto.MemberRegisterRequest;
+import com.nexters.momo.support.RandomPortConfigure;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/nexters/momo/acceptance/MyPageAcceptanceTest.java
+++ b/src/test/java/com/nexters/momo/acceptance/MyPageAcceptanceTest.java
@@ -1,0 +1,31 @@
+package com.nexters.momo.acceptance;
+
+import com.nexters.momo.member.auth.presentation.dto.MemberRegisterRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.nexters.momo.acceptance.AuthStep.로그인_되어_있음;
+import static com.nexters.momo.acceptance.AuthStep.사용자_가입_요청;
+import static com.nexters.momo.acceptance.MyPageStep.베어러_인증으로_내_회원_정보_조회_요청;
+import static com.nexters.momo.acceptance.MyPageStep.회원_정보_조회_확인;
+
+@DisplayName("인수 : 사용자 정보")
+public class MyPageAcceptanceTest extends RandomPortConfigure {
+
+    @DisplayName("사용자 본인의 프로필을 조회한다.")
+    @Test
+    public void find_member_info() {
+        // given
+        사용자_가입_요청(new MemberRegisterRequest("user@email.com",
+                "password", "shine", 22, "developer", "device_uuid"));
+
+        // when
+        String accessToken = 로그인_되어_있음("user@email.com", "password", "device_uuid");
+
+        // given
+        var 회원_정보_응답 = 베어러_인증으로_내_회원_정보_조회_요청(accessToken);
+
+        // then
+        회원_정보_조회_확인(회원_정보_응답, "user@email.com", "shine");
+    }
+}

--- a/src/test/java/com/nexters/momo/acceptance/MyPageStep.java
+++ b/src/test/java/com/nexters/momo/acceptance/MyPageStep.java
@@ -1,0 +1,31 @@
+package com.nexters.momo.acceptance;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+public class MyPageStep {
+
+    public static ExtractableResponse<Response> 베어러_인증으로_내_회원_정보_조회_요청(String accessToken) {
+        return RestAssured.given().log().all()
+                .auth().oauth2(accessToken)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .when().get("/api/mypages/me")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract();
+    }
+
+    public static void 회원_정보_조회_확인(ExtractableResponse<Response> response, String email, String name) {
+        assertAll(
+                () -> assertThat(response.jsonPath().getBoolean("data.active")).isFalse(),
+                () -> assertThat(response.jsonPath().getString("data.name")).isEqualTo(name),
+                () -> assertThat(response.jsonPath().getString("data.email")).isEqualTo(email)
+        );
+    }
+}

--- a/src/test/java/com/nexters/momo/acceptance/MyPageStep.java
+++ b/src/test/java/com/nexters/momo/acceptance/MyPageStep.java
@@ -23,9 +23,9 @@ public class MyPageStep {
 
     public static void 회원_정보_조회_확인(ExtractableResponse<Response> response, String email, String name) {
         assertAll(
-                () -> assertThat(response.jsonPath().getBoolean("data.active")).isFalse(),
-                () -> assertThat(response.jsonPath().getString("data.name")).isEqualTo(name),
-                () -> assertThat(response.jsonPath().getString("data.email")).isEqualTo(email)
+                () -> assertThat(response.jsonPath().getBoolean("active")).isFalse(),
+                () -> assertThat(response.jsonPath().getString("name")).isEqualTo(name),
+                () -> assertThat(response.jsonPath().getString("email")).isEqualTo(email)
         );
     }
 }

--- a/src/test/java/com/nexters/momo/session/service/SessionServiceTest.java
+++ b/src/test/java/com/nexters/momo/session/service/SessionServiceTest.java
@@ -3,7 +3,6 @@ package com.nexters.momo.session.service;
 import com.nexters.momo.session.application.SessionService;
 import com.nexters.momo.session.application.dto.SessionDto;
 import com.nexters.momo.session.domain.Session;
-import com.nexters.momo.session.dto.*;
 import com.nexters.momo.session.exception.InvalidSessionIdException;
 import com.nexters.momo.session.domain.SessionRepository;
 import org.junit.jupiter.api.DisplayName;


### PR DESCRIPTION
(해당 이슈 : #26 )

와 Role 권한 부여하는거 정말 빡시네요... 
간단하게, 만약 Role.Admin > Role.User 처럼 Admin이 더큰 집합의 권한을 보유하기 위해서
문자열로 "ROLE_ADMIN > ROLE_USER" 을 roleHierarchy에 등록시켜줘야 합니다.

## 구현 목록
- [x] 회원 정보 조회
- [x] Role 계층 권한 부여

## URL 접근 지정
지금 코드는 다음과 같이 로그인, 회원 가입 말고는 모두 USER권한이 필요하도록 설정해두었습니다!
![image](https://user-images.githubusercontent.com/60593969/219652682-a93a8e1a-6167-4e95-a7fe-9f562394e19e.png)
향후 ADMIN만 접근해야 하는 URL이 있다면, 빨간 박스 부분을 직관적으로 응용해주시면 될것 같습니다!