### PR TITLE
[Feat/#27] GitHub Action 적용

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,26 @@
+# This is a basic workflow to help you get started with Actions
+name: deploy
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the develop branch
+  push:
+    branches:
+      - develop
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  SSH:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run scripts in server
+        uses: appleboy/ssh-action@master
+        with:
+          key: ${{ secrets.SSH_KEY }}
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USER }}
+          script: |
+            cd ~
+            ./deploy.sh


### PR DESCRIPTION
### 요약
1. GitHub Action 을 적용해서 develop branch에 push할 경우 자동으로 EC2에서 배포되도록 설정

### 참고사항
1. 일반적인 방식 (S3에 배포 파일을 올려서 배포하는 방식)과 달리 간단하게 EC2 내부에 배포 스크립트를 저장해두고, 이를 GitHub Action에서 실행하는 방식을 사용했습니다!