### PR TITLE
[Feat/#21] Session 이미지 관련 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     compile 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
-    
+
     // swagger
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.7'
 

--- a/build.gradle
+++ b/build.gradle
@@ -52,9 +52,12 @@ dependencies {
     compile 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
-
+    
     // swagger
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.7'
+
+    // Spring Cloud AWS
+    implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.2'
 
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/nexters/momo/file/util/FileUtil.java
+++ b/src/main/java/com/nexters/momo/file/util/FileUtil.java
@@ -1,0 +1,107 @@
+package com.nexters.momo.file.util;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * AWS S3 관련 파일 관리를 담당하는 Util 클래스입니다.
+ *
+ * @author CHO Min Ho
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class FileUtil {
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    private final AmazonS3Client amazonS3Client;
+
+    // 파일 확장자는 .으로 구분
+    private static final String FILE_EXTENSION_SEPARATOR = ".";
+
+    // 파일 카테고리는 /으로 구분
+    private static final String CATEGORY_PREFIX = "/";
+
+    // 파일 생성일자는 _으로 구분
+    private static final String TIME_SEPARATOR = "_";
+
+    /**
+     * 파일과 해당 파일의 유형을 넘겨받아, AWS S3 bucket에 저장하고, 저장된 파일에 접근하는 URL을 반환합니다.
+     * 저장된 파일은 project/사진이름_1452152.jpg 와 같은 형식으로 작명됩니다.
+     * @param category 파일의 유형
+     * @param multipartFile 넘겨받은 multipartFile (파일)
+     * @return 업로드된 파일의 접근 URL
+     */
+    public String uploadFile(String category, MultipartFile multipartFile) {
+        if (multipartFile == null || multipartFile.isEmpty()) {
+            return null;
+        }
+        validateFileExists(multipartFile);
+
+        String fileName = buildFileName(category, multipartFile.getOriginalFilename());
+
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentType(multipartFile.getContentType());
+
+        try (InputStream inputStream = multipartFile.getInputStream()) {
+            amazonS3Client.putObject(new PutObjectRequest(bucketName, fileName, inputStream, objectMetadata)
+                    .withCannedAcl(CannedAccessControlList.PublicRead));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return amazonS3Client.getUrl(bucketName, fileName).toString();
+    }
+
+    /**
+     * S3 bucket 에서 특정 파일을 삭제합니다.
+     * @param url 삭제할 파일 접근 URL
+     */
+    public void deleteFile(String url) {
+        amazonS3Client.deleteObject(new DeleteObjectRequest(bucketName, getFileNameFromUrl(url)));
+    }
+
+    /**
+     * 객체 접근 URL 로부터 파일 이름을 반환합니다.
+     * @param url 파일 접근 URL
+     * @return 파일 이름
+     */
+    private String getFileNameFromUrl(String url) {
+        String baseUrl = "https://" + bucketName + ".s3.ap-northeast-2.amazonaws.com";
+        return url.substring(baseUrl.length());
+    }
+
+    /**
+     * 빈 파일일 경우, 예외를 던집니다.
+     * @param multipartFile 넘겨받은 multipartFile (파일)
+     */
+    private void validateFileExists(MultipartFile multipartFile) {
+        if (multipartFile.isEmpty()) {
+            throw new IllegalArgumentException("비어 있는 파일입니다!");
+        }
+    }
+
+    /**
+     * 파일의 유형, 이름, 현재 시간을 이용해서 저장된 파일 이름을 작명하고, 작명된 이름을 반환합니다.
+     * @param category 파일의 유형
+     * @param originalFileName 파일의 이름
+     * @return 작명된 파일 이름
+     */
+    private String buildFileName(String category, String originalFileName) {
+        int fileExtensionIndex = originalFileName.lastIndexOf(FILE_EXTENSION_SEPARATOR);
+        String fileExtension = originalFileName.substring(fileExtensionIndex);
+        String fileName = originalFileName.substring(0, fileExtensionIndex);
+        String now = String.valueOf(System.currentTimeMillis());
+
+        return category + CATEGORY_PREFIX + fileName + TIME_SEPARATOR + now + fileExtension;
+    }
+}

--- a/src/main/java/com/nexters/momo/session/application/SessionImageService.java
+++ b/src/main/java/com/nexters/momo/session/application/SessionImageService.java
@@ -1,0 +1,68 @@
+package com.nexters.momo.session.application;
+
+import com.nexters.momo.file.util.FileUtil;
+import com.nexters.momo.session.domain.SessionImage;
+import com.nexters.momo.session.domain.SessionImageRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 세션 이미지 관련 서비스 클래스입니다.
+ *
+ * @author CHO Min Ho
+ */
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class SessionImageService {
+
+    private final SessionImageRepository sessionImageRepository;
+    private final FileUtil fileUtil;
+    private final String category = "session";
+
+    /**
+     * 세션 이미지를 업로드하는 메서드입니다.
+     * @param id 세션 ID
+     * @param files 이미지 리스트
+     */
+    public void createSessionImage(Long id, List<MultipartFile> files) {
+
+        if (files != null) {
+            for (int i = 0; i < files.size(); i++) {
+                sessionImageRepository.save(
+                        SessionImage.createSessionImage(id, fileUtil.uploadFile(category, files.get(i)), i));
+            }
+        }
+    }
+
+    /**
+     * 세션 이미지를 삭제하는 메서드입니다.
+     * @param id 세션 ID
+     */
+    public void deleteSessionImage(Long id) {
+        sessionImageRepository.deleteBySessionId(id);
+    }
+
+    /**
+     * 특정 세션의 이미지 URL 리스트를 반환합니다.
+     * @param id 세션 ID
+     * @return 세션 URL 리스트
+     */
+    public List<String> getSessionImageList(Long id) {
+        List<String> result = new ArrayList<>();
+
+        for (SessionImage sessionImage : sessionImageRepository.findBySessionId(id)) {
+            result.add(sessionImage.getUrl());
+        }
+
+        return result;
+    }
+
+}

--- a/src/main/java/com/nexters/momo/session/application/dto/SessionDto.java
+++ b/src/main/java/com/nexters/momo/session/application/dto/SessionDto.java
@@ -9,6 +9,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
+import java.util.List;
 
 /**
  * Session 의 정보를 담고 있는 Dto 클래스입니다.

--- a/src/main/java/com/nexters/momo/session/domain/SessionImage.java
+++ b/src/main/java/com/nexters/momo/session/domain/SessionImage.java
@@ -1,0 +1,49 @@
+package com.nexters.momo.session.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+/**
+ * 세션 이미지 관련 엔티티 클래스입니다.
+ *
+ * @author CHO Min Ho
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SessionImage {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "session_image_id")
+    private Long id;
+
+    @Column(name = "session_id")
+    private Long sessionId;
+
+    private String url;
+
+    private int imageOrder;
+
+    private SessionImage(Long sessionId, String url, int imageOrder) {
+        this.sessionId = sessionId;
+        this.url = url;
+        this.imageOrder = imageOrder;
+    }
+
+    /**
+     * SessionImage 엔티티 생성 메서드입니다.
+     * @param sessionId 해당 session ID
+     * @param url 이미지 URL
+     * @param imageOrder 이미지 순서
+     * @return 생성된 SessionImage 엔티티
+     */
+    public static SessionImage createSessionImage(Long sessionId, String url, int imageOrder) {
+        return new SessionImage(sessionId, url, imageOrder);
+    }
+}

--- a/src/main/java/com/nexters/momo/session/domain/SessionImageRepository.java
+++ b/src/main/java/com/nexters/momo/session/domain/SessionImageRepository.java
@@ -1,0 +1,15 @@
+package com.nexters.momo.session.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+/**
+ * SessionImage JPA Repository 입니다.
+ *
+ * @author CHO Min Ho
+ */
+public interface SessionImageRepository extends JpaRepository<SessionImage, Long> {
+    List<SessionImage> findBySessionId(Long id);
+    void deleteBySessionId(Long id);
+}

--- a/src/main/java/com/nexters/momo/session/presentation/SessionApiSpec.java
+++ b/src/main/java/com/nexters/momo/session/presentation/SessionApiSpec.java
@@ -3,6 +3,7 @@ package com.nexters.momo.session.presentation;
 import com.nexters.momo.common.response.ErrorResponse;
 import com.nexters.momo.session.application.dto.SessionDto;
 import com.nexters.momo.session.presentation.dto.SessionRequest;
+import com.nexters.momo.session.presentation.dto.SessionResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -11,7 +12,10 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
 
+import javax.validation.Valid;
 import java.util.List;
 
 @Tag(name = "세션", description = "세션 API 목록")
@@ -31,7 +35,7 @@ public interface SessionApiSpec {
                     ),
             }
     )
-    ResponseEntity<SessionDto> getSingleSession(Long id);
+    ResponseEntity<SessionResponse> getSingleSession(Long id);
 
     @Operation(
             summary = "현재 기수의 모든 세션 조회",
@@ -59,7 +63,8 @@ public interface SessionApiSpec {
                     ),
             }
     )
-    ResponseEntity<Long> createNewSession(@RequestBody SessionRequest request);
+    ResponseEntity<Long> createNewSession(@RequestPart SessionRequest request,
+                                          @RequestPart List<MultipartFile> files);
 
     @Operation(
             summary = "세션 수정",
@@ -72,6 +77,8 @@ public interface SessionApiSpec {
                     ),
             }
     )
-    ResponseEntity<Long> updateSingleSession(Long id, @RequestBody SessionRequest request);
+    ResponseEntity<Long> updateSingleSession(Long id,
+                                             @RequestPart SessionRequest request,
+                                             @RequestPart List<MultipartFile> files);
 }
 

--- a/src/main/java/com/nexters/momo/session/presentation/dto/SessionResponse.java
+++ b/src/main/java/com/nexters/momo/session/presentation/dto/SessionResponse.java
@@ -1,0 +1,24 @@
+package com.nexters.momo.session.presentation.dto;
+
+import com.nexters.momo.session.application.dto.SessionDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 세션을 조회할 때 반환하는 Response 객체입니다.
+ *
+ * @author CHO Min Ho
+ */
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SessionResponse {
+
+    private SessionDto sessionDto;
+
+    private List<String> files;
+
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -32,6 +32,19 @@ jwt:
   access-key: ${jwt.access.key}
   refresh-key: ${jwt.refresh.key}
 
+# AWS S3 관련 설정
+cloud:
+  aws:
+    credentials:
+      access-key: ${iam.access.key}
+      secret-key: ${iam.secret.key}
+    region:
+      static: ap-northeast-2
+    s3:
+      bucket: ${s3.bucket.name}
+    stack:
+      auto: false
+
 springdoc:
   version: v.1.0.0
   packages-to-scan: com.nexters.momo

--- a/src/test/java/com/nexters/momo/session/application/SessionImageServiceTest.java
+++ b/src/test/java/com/nexters/momo/session/application/SessionImageServiceTest.java
@@ -1,0 +1,54 @@
+package com.nexters.momo.session.application;
+
+import com.nexters.momo.session.domain.SessionImage;
+import com.nexters.momo.session.domain.SessionImageRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+@DisplayName("세션 이미지 서비스 테스트")
+class SessionImageServiceTest {
+
+    @Autowired
+    private SessionImageService sessionImageService;
+
+    @Autowired
+    private SessionImageRepository sessionImageRepository;
+
+    @Test
+    @DisplayName("세션 이미지 삭제 테스트")
+    void delete_session_image() {
+        // given
+        sessionImageRepository.save(SessionImage.createSessionImage(1L, "aaa.com", 1));
+        sessionImageRepository.save(SessionImage.createSessionImage(1L, "bbb.com", 2));
+
+        // when
+        sessionImageService.deleteSessionImage(1L);
+
+        // then
+        assertThat(sessionImageRepository.findBySessionId(1L).size()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("세션 이미지 조회 테스트")
+    void get_session_image() {
+        // given
+        sessionImageRepository.save(SessionImage.createSessionImage(1L, "aaa.com", 1));
+        sessionImageRepository.save(SessionImage.createSessionImage(1L, "bbb.com", 2));
+
+        // when
+        List<String> sessionImageList = sessionImageService.getSessionImageList(1L);
+
+        // then
+        assertThat(sessionImageList.size()).isEqualTo(2);
+    }
+
+}

--- a/src/test/java/com/nexters/momo/session/application/SessionServiceTest.java
+++ b/src/test/java/com/nexters/momo/session/application/SessionServiceTest.java
@@ -1,4 +1,4 @@
-package com.nexters.momo.session.service;
+package com.nexters.momo.session.application;
 
 import com.nexters.momo.session.application.SessionService;
 import com.nexters.momo.session.application.dto.SessionDto;

--- a/src/test/java/com/nexters/momo/session/domain/SessionImageTest.java
+++ b/src/test/java/com/nexters/momo/session/domain/SessionImageTest.java
@@ -1,0 +1,24 @@
+package com.nexters.momo.session.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.nexters.momo.session.domain.SessionImage.createSessionImage;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * SessionImage 엔티티 테스트입니다.
+ *
+ * @author CHO Min Ho
+ */
+@DisplayName("세션 이미지 도메인 테스트")
+class SessionImageTest {
+
+    @DisplayName("세션 이미지 생성 테스트")
+    @Test
+    void create_session_image() {
+        assertThatCode(() -> createSessionImage(1L, "aaa.com", 1))
+                .doesNotThrowAnyException();
+    }
+
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -27,6 +27,19 @@ jwt:
   refresh-key:
     testPrivateKeytestPrivateKeytestPrivateKeytestPrivateKeytestPrivateKeytestPrivateKeytestPrivateKeytestPrivateKeytestPrivateKey
 
+# AWS S3 관련 설정
+cloud:
+  aws:
+    credentials:
+      access-key: test_access_key
+      secret-key: test_secret_key
+    region:
+      static: ap-northeast-2
+    s3:
+      bucket: test_bucket_name
+    stack:
+      auto: false
+
 springdoc:
   version: v.1.0.0
   packages-to-scan: com.nexters.momo


### PR DESCRIPTION
(해당 이슈 : #21)

### 구현 설명
1. AWS S3 관련 설정 완료
2. 세션 이미지 엔티티 생성
3. 세션 이미지 관련 로직 기존 세션 로직에 추가